### PR TITLE
Update heparse.c

### DIFF
--- a/hugo/heparse.c
+++ b/hugo/heparse.c
@@ -1087,7 +1087,12 @@ int MatchObject(int *wordnum)
 
 				/* definitely not this object */
 				else
+				{
 					SubtractPossibleObject(i);
+					/* clear bestobj if i is the current best object */
+					if (i == bestobj)
+						bestobj = 0;
+				}
 			}
 
 


### PR DESCRIPTION
Fixes a bug that comes up if someone refers to a known object not in scope that shares an adjective with another known out of scope object.  Without the fix, the first defined object always gets sent to ParseError, ignoring the difference of nouns and such.